### PR TITLE
feat: hide Hemi mainnet until ready

### DIFF
--- a/src/chains.ts
+++ b/src/chains.ts
@@ -22,7 +22,7 @@ export enum ChainId {
   ZORA_SEPOLIA = 999999999,
   ROOTSTOCK = 30,
   BLAST = 81457,
-  HEMI = 43_111,
+  // HEMI = 43_111,
   HEMI_SEPOLIA = 743_111
 }
 


### PR DESCRIPTION
Hiding Hemi Mainnet until it is ready, because otherwise it will cause compilation issues in other dependant packages